### PR TITLE
Add automatic GitHub-Workflow to build and publish plugins on a dedicated gh-pages branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 18
 
       - name: Install Dependencies
         run: npm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Install Dependencies
         run: npm install
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,73 @@
+name: Build and Deploy Plugins
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      artifact-name: ${{ steps.upload.outputs.artifact-name }}
+    steps:
+      - name: Checkout Repository (with Submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Install Submodule Dependencies
+        run: npm install
+        working-directory: openscd
+
+      - name: Build Submodule
+        run: npm run build
+        working-directory: openscd
+
+      - name: Build Project
+        run: npm run build
+
+      - name: Upload Build Artifact
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages Branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Copy Built Files to Plugins Folder
+        run: |
+          mkdir -p plugins
+          cp -r dist/* plugins/
+
+      - name: Commit and Push Changes
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add plugins
+          git commit -m "Deploy latest build to plugins" || echo "No changes to commit"
+          git push origin gh-pages


### PR DESCRIPTION
# OSCD Plugin Publishing

To publish oscd official plugins i created a github action that publishes new versions of plugins to github pages whenever a push or pull request on main branch occurs.